### PR TITLE
Remove hardcoded dark mode class

### DIFF
--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
     @include('partials.head')

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
     @include('partials.head')

--- a/resources/views/components/layouts/auth/card.blade.php
+++ b/resources/views/components/layouts/auth/card.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
     @include('partials.head')

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
     @include('partials.head')

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
     @include('partials.head')

--- a/resources/views/livewire/settings/appearance.blade.php
+++ b/resources/views/livewire/settings/appearance.blade.php
@@ -50,29 +50,10 @@
             </div>
 
             <!-- Theme Options -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4" x-data="{ 
-                selectedTheme: localStorage.theme || 'system',
-                setTheme(theme) {
-                    this.selectedTheme = theme;
-                    if (theme === 'light') {
-                        localStorage.theme = 'light';
-                        document.documentElement.classList.remove('dark');
-                    } else if (theme === 'dark') {
-                        localStorage.theme = 'dark';
-                        document.documentElement.classList.add('dark');
-                    } else {
-                        localStorage.removeItem('theme');
-                        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                            document.documentElement.classList.add('dark');
-                        } else {
-                            document.documentElement.classList.remove('dark');
-                        }
-                    }
-                }
-            }">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4" x-data>
                 <!-- Light Theme -->
-                <div @click="setTheme('light')"
-                    :class="selectedTheme === 'light' ? 'ring-2 ring-[#4586FF] dark:ring-[#99BDFF] ring-offset-2 ring-offset-white dark:ring-offset-slate-800' : ''"
+                <div @click="$flux.appearance = 'light'"
+                    :class="$flux.appearance === 'light' ? 'ring-2 ring-[#4586FF] dark:ring-[#99BDFF] ring-offset-2 ring-offset-white dark:ring-offset-slate-800' : ''"
                     class="group relative cursor-pointer rounded-2xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 transition-all duration-300 hover:border-[#4586FF] dark:hover:border-[#99BDFF] hover:shadow-lg hover:shadow-blue-500/10 dark:hover:shadow-blue-400/10">
 
                     <!-- Theme Preview -->
@@ -98,7 +79,7 @@
                         </div>
 
                         <!-- Selection Indicator -->
-                        <div x-show="selectedTheme === 'light'"
+                        <div x-show="$flux.appearance === 'light'"
                             class="absolute top-2 right-2 w-6 h-6 bg-[#4586FF] rounded-full flex items-center justify-center shadow-lg">
                             <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3"
@@ -123,8 +104,8 @@
                 </div>
 
                 <!-- Dark Theme -->
-                <div @click="setTheme('dark')"
-                    :class="selectedTheme === 'dark' ? 'ring-2 ring-[#4586FF] dark:ring-[#99BDFF] ring-offset-2 ring-offset-white dark:ring-offset-slate-800' : ''"
+                <div @click="$flux.appearance = 'dark'"
+                    :class="$flux.appearance === 'dark' ? 'ring-2 ring-[#4586FF] dark:ring-[#99BDFF] ring-offset-2 ring-offset-white dark:ring-offset-slate-800' : ''"
                     class="group relative cursor-pointer rounded-2xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 transition-all duration-300 hover:border-[#4586FF] dark:hover:border-[#99BDFF] hover:shadow-lg hover:shadow-blue-500/10 dark:hover:shadow-blue-400/10">
 
                     <!-- Theme Preview -->
@@ -150,7 +131,7 @@
                         </div>
 
                         <!-- Selection Indicator -->
-                        <div x-show="selectedTheme === 'dark'"
+                        <div x-show="$flux.appearance === 'dark'"
                             class="absolute top-2 right-2 w-6 h-6 bg-[#99BDFF] rounded-full flex items-center justify-center shadow-lg">
                             <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3"
@@ -175,8 +156,8 @@
                 </div>
 
                 <!-- System Theme -->
-                <div @click="setTheme('system')"
-                    :class="selectedTheme === 'system' ? 'ring-2 ring-[#4586FF] dark:ring-[#99BDFF] ring-offset-2 ring-offset-white dark:ring-offset-slate-800' : ''"
+                <div @click="$flux.appearance = 'system'"
+                    :class="$flux.appearance === 'system' ? 'ring-2 ring-[#4586FF] dark:ring-[#99BDFF] ring-offset-2 ring-offset-white dark:ring-offset-slate-800' : ''"
                     class="group relative cursor-pointer rounded-2xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 transition-all duration-300 hover:border-[#4586FF] dark:hover:border-[#99BDFF] hover:shadow-lg hover:shadow-blue-500/10 dark:hover:shadow-blue-400/10">
 
                     <!-- Theme Preview -->
@@ -211,7 +192,7 @@
                         </div>
 
                         <!-- Selection Indicator -->
-                        <div x-show="selectedTheme === 'system'"
+                        <div x-show="$flux.appearance === 'system'"
                             class="absolute top-2 right-2 w-6 h-6 bg-gradient-to-r from-[#4586FF] to-[#99BDFF] rounded-full flex items-center justify-center shadow-lg">
                             <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -11,15 +11,7 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700,800,900" rel="stylesheet" />
 
-    <!-- Theme Detection Script (Must be before Tailwind) -->
-    <script>
-        if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia(
-            '(prefers-color-scheme: dark)').matches)) {
-            document.documentElement.classList.add('dark')
-        } else {
-            document.documentElement.classList.remove('dark')
-        }
-    </script>
+    <!-- Theme handled by Flux -->
 
     <!-- Tailwind CSS -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
@@ -30,32 +22,7 @@
 
 <body
     class="bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/20 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 text-slate-900 dark:text-white antialiased transition-colors duration-300"
-    x-data="{ 
-        darkMode: localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches),
-        toggleDarkMode() {
-            this.darkMode = !this.darkMode;
-            if (this.darkMode) {
-                document.documentElement.classList.add('dark');
-                localStorage.theme = 'dark';
-            } else {
-                document.documentElement.classList.remove('dark');
-                localStorage.theme = 'light';
-            }
-        }
-    }" x-init="
-        // Listen for system theme changes
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-            if (!('theme' in localStorage)) {
-                if (e.matches) {
-                    document.documentElement.classList.add('dark');
-                    darkMode = true;
-                } else {
-                    document.documentElement.classList.remove('dark');
-                    darkMode = false;
-                }
-            }
-        });
-    ">
+    x-data>
 
     <!-- Navigation -->
     <nav
@@ -96,16 +63,16 @@
                 <!-- Right Side: Theme Toggle + Auth Buttons -->
                 <div class="flex items-center space-x-4">
                     <!-- Theme Toggle Button -->
-                    <button @click="toggleDarkMode()"
+                    <button @click="$flux.appearance = $flux.appearance === 'dark' ? 'light' : 'dark'"
                         class="p-2 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-all duration-300 border border-slate-200 dark:border-slate-700"
-                        :aria-label="darkMode ? 'Switch to light mode' : 'Switch to dark mode'">
+                        :aria-label="$flux.appearance === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'">
                         <!-- Sun Icon (Light Mode) -->
-                        <svg x-show="darkMode" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg x-show="$flux.appearance === 'dark'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                 d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
                         </svg>
                         <!-- Moon Icon (Dark Mode) -->
-                        <svg x-show="!darkMode" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg x-show="$flux.appearance !== 'dark'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                 d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
                         </svg>


### PR DESCRIPTION
## Summary
- rely on the appearance script for dark mode
- update layouts to drop the `class="dark"` attribute
- make settings theme cards update `$flux.appearance`
- use `$flux.appearance` in welcome page toggle

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_687954beb3a0832a94970fe1d3d39b6a